### PR TITLE
Allow annotations to be used for Python 3 Tasks

### DIFF
--- a/tests/collection.py
+++ b/tests/collection.py
@@ -229,7 +229,7 @@ class Collection_(Spec):
         def raises_ValueError_if_no_name_found(self):
             # Can't use a lambda here as they are technically real functions.
             class Callable(object):
-                def __call__(self):
+                def __call__(self, ctx):
                     pass
             self.c.add_task(Task(Callable()))
 


### PR DESCRIPTION
Use inspect.signature instead of inspect.getargspect when
using Python 3 to allow function annotations to be used in tasks.

Also fix missing context in Collection test.

Fixes #357

Make Travis CI flake8 exit with 0

Revert adding custom exception